### PR TITLE
:sparkles: (request-access): Request access mutation now requires input parameters

### DIFF
--- a/libs/api/request-access/api/feature/src/lib/api-request-access.resolver.ts
+++ b/libs/api/request-access/api/feature/src/lib/api-request-access.resolver.ts
@@ -1,4 +1,4 @@
-import { Mutation, Resolver } from "@nestjs/graphql";
+import { Args, ID, Mutation, Resolver } from "@nestjs/graphql";
 import { ApiRequestAccessEntity } from "./api-request-access.entity";
 import { ApiRequestAccessService } from "./api-request-access.service";
 
@@ -8,7 +8,7 @@ export class ApiRequestAccessResolver {
 
     @Mutation(returns => ApiRequestAccessEntity)
     // must add paramters to request
-    requestAccess(): Promise<ApiRequestAccessEntity> {
+    async requestAccess(@Args('compID', { type: () => ID }) compId: string, @Args('userID', { type: () => ID }) userId: string, @Args('item') id: string): Promise<ApiRequestAccessEntity> {
         return this.requestAccessService.makeRequest();
     }
 }


### PR DESCRIPTION
The mutation now requires the caller to input the company and user id as well as the item for which they are requesting access for.