### PR TITLE
💄(ui): Add universal breakpoints to global styles

### DIFF
--- a/libs/client/shared/assets/global.scss
+++ b/libs/client/shared/assets/global.scss
@@ -21,5 +21,28 @@ $card-blue : #174372;
 $card-gold : #C48939;
 $card-red : #DC3545;
 
+//Breakpoints
+$desktop-width: 1024px;
+$tablet-width: 768px;
+
+@mixin desktop {
+  @media (min-width: #{$desktop-width}) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media (min-width: #{$tablet-width}) and (max-width: #{$desktop-width - 1px}) {
+    @content;
+  }
+}
+
+@mixin phone {
+  @media (max-width: #{$tablet-width - 1px}) {
+    @content;
+  }
+}
+
+
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
Adding universal breakpoints as mixins to the global stylesheet.
Mixins can be used as follows:

```
.someClass {
  //style rules which apply regardless of screen size

  @include tablet {
    //style rules which only apply to tablet displays
  }

  @include phone {
    //style rules which only apply to phone displays
  }
}
```