### PR TITLE
🙈(repo): remove yarn.lock from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,3 @@ Thumbs.db
 
 # NPM
 /package-lock.json
-/yarn.lock


### PR DESCRIPTION
see: https://yarnpkg.com/getting-started/qa/#should-lockfiles-be-committed-to-the-repository