### PR TITLE
✨ (api): getAccessEntity Takes in 3 parameters

### DIFF
--- a/libs/api/request-access/service/feature/src/lib/request-access.service.ts
+++ b/libs/api/request-access/service/feature/src/lib/request-access.service.ts
@@ -3,11 +3,11 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class RequestAccessService {
-    async getAccessEntity(companyID: string, userID: string): Promise<ApiRequestAccessEntity> {
+    async getAccessEntity(companyID: string, userID: string, item: string): Promise<ApiRequestAccessEntity> {
         const entity = {
           companyID: companyID,
           userID: userID,
-          item: 'private',
+          item: item,
         };
     
         return entity;


### PR DESCRIPTION
getAccessEntity Takes in 3 parameters not 2