### PR TITLE
🩹 (UI) - Replaces userID with user name and email in notification output

### DIFF
--- a/libs/client/notifications/feature/src/lib/expansion-notif/expansion-notif.component.html
+++ b/libs/client/notifications/feature/src/lib/expansion-notif/expansion-notif.component.html
@@ -9,7 +9,7 @@
       <mat-list-item>
         <mat-icon matListIcon>account_circle</mat-icon>
         <h3 matLine>{{userFrom}}</h3>
-        <h3 matLine>{{userFrom}}@gmail.co.za</h3>
+        <h3 matLine>{{userEmailFrom}}</h3>
         <p>{{description}}</p>
       </mat-list-item>
       <mat-action-row class="matActionRow">

--- a/libs/client/notifications/feature/src/lib/expansion-notif/expansion-notif.component.ts
+++ b/libs/client/notifications/feature/src/lib/expansion-notif/expansion-notif.component.ts
@@ -8,6 +8,7 @@ import { Component, Input, OnInit } from '@angular/core';
 export class ExpansionNotifComponent implements OnInit {
   @Input() public description!: string;
   @Input() public userFrom!: string;
+  @Input() public userEmailFrom!: string;
   @Input() public userTo!: string;
   @Input() public requestedItem!: string;
   constructor() {

--- a/libs/client/notifications/feature/src/lib/notif-display/notif-display.api.ts
+++ b/libs/client/notifications/feature/src/lib/notif-display/notif-display.api.ts
@@ -9,14 +9,30 @@ export class NotificationsApi {
     constructor(private httpClient: HttpClient) {}
 
     getNotificationsAll():Observable<any | null> {
-        const query = `query { 
-            notificationsAll { 
-                id, 
+        const query = `query {
+            notificationsAll {
+                id,
                 data{notificationType},
                 userIdTo,
                 userIdFrom
             }
         }`
+        const options = {
+            headers: new HttpHeaders({
+                'Content-Type': 'application/json'
+            })
+        }
+
+        return this.httpClient.post<any>('http://localhost:3333/graphql', JSON.stringify({ query: query}), options);
+    }
+
+    getUserEmailAndName(userId : string): Observable<any | null> {
+        const query = `query {
+            notificationsGetUser(userId: "${userId}") {
+              name
+              email
+            }
+          }`
         const options = {
             headers: new HttpHeaders({
                 'Content-Type': 'application/json'

--- a/libs/client/notifications/feature/src/lib/notif-display/notif-display.component.ts
+++ b/libs/client/notifications/feature/src/lib/notif-display/notif-display.component.ts
@@ -23,7 +23,21 @@ export class NotifDisplayComponent implements OnInit{
         for (let i = notArr.length-1; i >= 0 ; i--) {
           const comp = this.placeholder.createComponent(ExpansionNotifComponent);
           comp.instance.description = 'Request for '+ res.data.notificationsAll[i].data.notificationType;
-          comp.instance.userFrom = res.data.notificationsAll[i].userIdFrom;
+          const idFrom = res.data.notificationsAll[i].userIdFrom;
+          this.notifApi.getUserEmailAndName(idFrom).subscribe({
+            next: (result) => {
+              comp.instance.userFrom = result.data.notificationsGetUser.name;
+              comp.instance.userEmailFrom = result.data.notificationsGetUser.email;
+            }
+          });
+
+          const idTo = res.data.notificationsAll[i].userIdTo;
+          this.notifApi.getUserEmailAndName(idTo).subscribe({
+            next: (result) => {
+              comp.instance.userTo = result.data.notificationsGetUser.name;
+            }
+          });
+          
           comp.instance.userTo = res.data.notificationsAll[i].userIdTo;
           comp.instance.requestedItem = res.data.notificationsAll[i].data.notificationType;
         }

--- a/libs/client/student-requests/feature/src/lib/requests-tab/requests-tab.api.ts
+++ b/libs/client/student-requests/feature/src/lib/requests-tab/requests-tab.api.ts
@@ -11,8 +11,8 @@ export class RequestTabApi {
     requestCV():Observable<any | null> {
         const query = `mutation { 
             createRequestNotification (
-                userIDTo: "cl20wx4ka0061boun3qhcpkzq",
-                userIDFrom: "cl20wxms80114bounbcjvfui4",
+                userIdTo: "cl20wx4ka0061boun3qhcpkzq",
+                userIdFrom: "cl2374vfa0253i8unx7r7eeb5",
                 notificationType: "CV"
             ) {
             data {
@@ -32,8 +32,8 @@ export class RequestTabApi {
     requestCD():Observable<any | null> {
         const query = `mutation { 
             createRequestNotification (
-                userIDTo: "cl20wx4ka0061boun3qhcpkzq",
-                userIDFrom: "cl20wxms80114bounbcjvfui4",
+                userIdTo: "cl20wx4ka0061boun3qhcpkzq",
+                userIdFrom: "cl20wxms80114bounbcjvfui4",
                 notificationType: "Contact Details"
             ) {
             data {
@@ -53,8 +53,8 @@ export class RequestTabApi {
     requestAR():Observable<any | null> {
         const query = `mutation { 
             createRequestNotification (
-                userIDTo: "cl20wx4ka0061boun3qhcpkzq",
-                userIDFrom: "cl20wxms80114bounbcjvfui4",
+                userIdTo: "cl20wx4ka0061boun3qhcpkzq",
+                userIdFrom: "cl2378g130404i8unncj003ay",
                 notificationType: "Academic Record"
             ) {
             data {


### PR DESCRIPTION
Notifications displays correct name and email instead of user ID.
Fixes #752 