### PR TITLE
:bug: (Blog) Fixed parameters and return values for various API endpoints

### DIFF
--- a/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.spec.ts
+++ b/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.spec.ts
@@ -276,14 +276,14 @@ describe('BlogCommentResolver', () => {
         .spyOn(resolver, 'createComment')
         .mockImplementation((): Promise<BlogComment> => Promise.resolve(BlogCommentMock));
 
-      expect(await resolver.createComment('H36','347','Q23','This is a test Comment')).toMatchObject(
+      expect(await resolver.createComment('347','Q23','This is a test Comment')).toMatchObject(
         BlogCommentMock
       )
     });
     it('should return null', async () => {
       jest.spyOn(resolver, 'createComment').mockResolvedValue(null);
   
-      expect(await resolver.createComment('NULL','NULL','NULL','This is a test Comment')).toEqual(null);
+      expect(await resolver.createComment('NULL','NULL','This is a test Comment')).toEqual(null);
     });
   });
 

--- a/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.ts
+++ b/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.ts
@@ -1,6 +1,7 @@
 import { Resolver, Query, Args, Mutation, ResolveField, Root } from '@nestjs/graphql';
 import { Blog, BlogComment, BlogMedia } from '@graduates/api/blog/api/shared/entities/data-access';
 import { BlogService } from '@graduates/api/blog/service/feature';
+import { User } from '@graduates/api/authentication/api/shared/interfaces/data-access';
 
 @Resolver(() => Blog)
 export class BlogResolver {
@@ -53,8 +54,8 @@ export class BlogResolver {
      * @param {string} userId The id of the user
      * @return {Promise<string | null>} 
      */
-    @Query(returns => String)
-    async nameByUserId(@Args('userId', {type: () => String}) userId: string): Promise<string | null> {
+    @Query(returns => User)
+    async nameByUserId(@Args('userId', {type: () => String}) userId: string): Promise<User | null> {
         return this.blogService.getNameByUserId(userId);
     }
 
@@ -172,7 +173,6 @@ export class BlogCommentResolver {
 
     /**
      * Create a comment
-     * @param {string} id The id of the comment
      * @param {string} blogId The id of the blog the comment is made on
      * @param {string} userId The id of the user who posted the comment
      * @param {string} content The  content of the comment
@@ -180,12 +180,11 @@ export class BlogCommentResolver {
      */
     @Mutation(returns => BlogComment)
     async createComment( 
-        @Args('id', {type: () => String}) id : string, 
         @Args('blogId', {type: () => String}) blogId : string, 
         @Args('userId', {type: () => String}) userId : string, 
         @Args('content', {type: () => String}) content : string
     ) : Promise<BlogComment | null> {
-        return this.blogService.createComment(id, blogId, userId, content);
+        return this.blogService.createComment(blogId, userId, content);
     }
 
     /**

--- a/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.ts
+++ b/libs/api/blog/api/feature/src/lib/api-blog-resolver.resolver.ts
@@ -1,7 +1,7 @@
 import { Resolver, Query, Args, Mutation, ResolveField, Root } from '@nestjs/graphql';
 import { Blog, BlogComment, BlogMedia } from '@graduates/api/blog/api/shared/entities/data-access';
 import { BlogService } from '@graduates/api/blog/service/feature';
-import { User } from '@graduates/api/authentication/api/shared/interfaces/data-access';
+import { AuthenticationUser } from '@graduates/api/authentication/api/shared/interfaces/data-access';
 
 @Resolver(() => Blog)
 export class BlogResolver {
@@ -52,10 +52,10 @@ export class BlogResolver {
     /**
      * Find the name of the user with the given id
      * @param {string} userId The id of the user
-     * @return {Promise<string | null>} 
+     * @return {Promise<AuthenticationUser | null>} 
      */
-    @Query(returns => User)
-    async nameByUserId(@Args('userId', {type: () => String}) userId: string): Promise<User | null> {
+    @Query(returns => AuthenticationUser)
+    async nameByUserId(@Args('userId', {type: () => String}) userId: string): Promise<AuthenticationUser | null> {
         return this.blogService.getNameByUserId(userId);
     }
 

--- a/libs/api/blog/repository/data-access/src/lib/api-blog-repository.repository.spec.ts
+++ b/libs/api/blog/repository/data-access/src/lib/api-blog-repository.repository.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BlogRepository } from './api-blog-repository.repository';
 import { PrismaService } from '@graduates/api/shared/services/prisma/data-access';
-import { Blog, BlogComment, BlogMedia  } from '@graduates/api/blog/api/shared/entities/data-access';
+import { Blog, BlogComment, BlogMedia } from '@graduates/api/blog/api/shared/entities/data-access';
 
 jest.mock('@graduates/api/blog/api/shared/entities/data-access');
 
@@ -230,14 +230,14 @@ describe('BlogRepository', () => {
         .spyOn(repository, 'createComment')
         .mockImplementation((): Promise<BlogComment> => Promise.resolve(blogCommentMock));
 
-        expect(await repository.createComment('32A',"45H",'35','New Comment to be added')).toMatchObject(
+        expect(await repository.createComment("45H",'35','New Comment to be added')).toMatchObject(
           blogCommentMock
         )
     });
     it('should return null', async () => {
       jest.spyOn(repository, 'createComment').mockResolvedValue(null);
   
-      expect(await repository.createComment('NULL',"NULL",'NULL','New Comment to be added')).toEqual(null);
+      expect(await repository.createComment("NULL",'NULL','New Comment to be added')).toEqual(null);
     });
   });
   //Test updateComment function

--- a/libs/api/blog/repository/data-access/src/lib/api-blog-repository.repository.ts
+++ b/libs/api/blog/repository/data-access/src/lib/api-blog-repository.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '@graduates/api/shared/services/prisma/data-access';
-import { Blog, BlogComment, BlogMedia } from '@prisma/client';
+import { Blog, BlogComment, BlogMedia, User } from '@prisma/client';
 
 @Injectable()
 export class BlogRepository {
@@ -61,15 +61,10 @@ export class BlogRepository {
   /**
    * Find the name of the user with the given id
    * @param {string} userId The id of the user
-   * @return {Promise<string | null>} 
+   * @return {Promise<User | null>} 
    */
-  async findNameByUserId(userId: string): Promise<string | null> {
-    const res = await this.prisma.user.findUnique({ where: { id: userId } });
-
-    if (res)
-      return res.name;
-
-    return null;
+  async findNameByUserId(userId: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { id: userId } });
   }
 
   /**
@@ -204,17 +199,15 @@ export class BlogRepository {
 
   /**
    * Create a comment
-   * @param {string} id The id of the comment
    * @param {string} blogId The id of the blog the comment is made on
    * @param {string} userId The id of the user who posted the comment
    * @param {string} content The  content of the comment
    * @return {Promise<BlogComment | null>} 
    */
-  async createComment(id: string, blogId: string, userId: string, content: string): Promise<BlogComment | null> {
+  async createComment(blogId: string, userId: string, content: string): Promise<BlogComment | null> {
     return this.prisma.blogComment.create({
       data: {
         userId: userId,
-        id: id,
         blogId: blogId,
         content: content,
         date: new Date()

--- a/libs/api/blog/service/feature/src/lib/api-blog-service.service.spec.ts
+++ b/libs/api/blog/service/feature/src/lib/api-blog-service.service.spec.ts
@@ -124,14 +124,14 @@ describe('BlogService', () => {
     .spyOn(service, 'createComment')
     .mockImplementation((): Promise<BlogComment> => Promise.resolve(BlogCommentMock));
 
-    expect(await service.createComment('1','2A4','38GB23J','This is a new Comment')).toMatchObject(
+    expect(await service.createComment('2A4','38GB23J','This is a new Comment')).toMatchObject(
       BlogCommentMock
     )
   });
   it('should return null', async () => {
     jest.spyOn(service, 'createComment').mockResolvedValue(null);
 
-    expect(await service.createComment('NULL','NULL','NULL','This is a new Comment')).toEqual(null);
+    expect(await service.createComment('NULL','NULL','This is a new Comment')).toEqual(null);
   });
 })
 

--- a/libs/api/blog/service/feature/src/lib/api-blog-service.service.ts
+++ b/libs/api/blog/service/feature/src/lib/api-blog-service.service.ts
@@ -21,7 +21,7 @@ import {
   GetCommentByCommentIdQuery, 
   GetMediaByBlogIdQuery,
   GetNameByUserIdQuery } from './queries/api-blog-query.query';
-import { User } from '@graduates/api/authentication/api/shared/interfaces/data-access';
+import { AuthenticationUser } from '@graduates/api/authentication/api/shared/interfaces/data-access';
 
 @Injectable()
 export class BlogService {
@@ -204,9 +204,9 @@ export class BlogService {
   /**
    * Find the name of the user with the given id
    * @param {string} userId The id of the user
-   * @return {Promise<User | null>} 
+   * @return {Promise<AuthenticationUser | null>} 
    */
-   async getNameByUserId(userId: string): Promise<User | null> {
+   async getNameByUserId(userId: string): Promise<AuthenticationUser | null> {
     return await this.queryBus.execute(
       new GetNameByUserIdQuery(userId)
     );

--- a/libs/api/blog/service/feature/src/lib/api-blog-service.service.ts
+++ b/libs/api/blog/service/feature/src/lib/api-blog-service.service.ts
@@ -21,6 +21,7 @@ import {
   GetCommentByCommentIdQuery, 
   GetMediaByBlogIdQuery,
   GetNameByUserIdQuery } from './queries/api-blog-query.query';
+import { User } from '@graduates/api/authentication/api/shared/interfaces/data-access';
 
 @Injectable()
 export class BlogService {
@@ -99,15 +100,14 @@ export class BlogService {
 
   /**
    * Create a comment
-   * @param {string} id The id of the comment
    * @param {string} blogId The id of the blog the comment is made on
    * @param {string} userId The id of the user who posted the comment
    * @param {string} content The  content of the comment
    * @return {Promise<BlogComment | null>} 
    */
-  async createComment(id: string, blogId: string, userId: string, content: string): Promise<BlogComment | null> {
+  async createComment(blogId: string, userId: string, content: string): Promise<BlogComment | null> {
     return await this.commandBus.execute(
-      new CreateCommentCommand(id, blogId, userId, content)
+      new CreateCommentCommand(blogId, userId, content)
     );
   }
 
@@ -204,9 +204,9 @@ export class BlogService {
   /**
    * Find the name of the user with the given id
    * @param {string} userId The id of the user
-   * @return {Promise<string | null>} 
+   * @return {Promise<User | null>} 
    */
-   async getNameByUserId(userId: string): Promise<string | null> {
+   async getNameByUserId(userId: string): Promise<User | null> {
     return await this.queryBus.execute(
       new GetNameByUserIdQuery(userId)
     );

--- a/libs/api/blog/service/feature/src/lib/commands/api-blog-command-handler.handler.ts
+++ b/libs/api/blog/service/feature/src/lib/commands/api-blog-command-handler.handler.ts
@@ -70,8 +70,8 @@ export class CreateCommentHandler implements ICommandHandler<CreateCommentComman
   constructor(private readonly repository: BlogRepository) {}
 
   async execute(command: CreateCommentCommand) {
-    const { id, blogId, userId, content } = command; 
-    return this.repository.createComment(id, blogId, userId, content);
+    const { blogId, userId, content } = command; 
+    return this.repository.createComment(blogId, userId, content);
   }
 }
 

--- a/libs/api/blog/service/feature/src/lib/commands/api-blog-command.command.ts
+++ b/libs/api/blog/service/feature/src/lib/commands/api-blog-command.command.ts
@@ -40,7 +40,6 @@ export class DeleteBlogCommand {
 
 export class CreateCommentCommand {
   constructor(
-    public readonly id, 
     public readonly blogId, 
     public readonly userId, 
     public readonly content


### PR DESCRIPTION
Changed the return type of getNameByUserId from string to User

Removed the id parameter from createComment