### PR TITLE
🐛(storage/api): fix resolver test issues with return types

### DIFF
--- a/libs/api/storage/api/feature/src/lib/api-storage.resolver.spec.ts
+++ b/libs/api/storage/api/feature/src/lib/api-storage.resolver.spec.ts
@@ -17,7 +17,7 @@ describe('ApStorageResolver', () => {
     expect(resolver).toBeDefined();
   });
 });
-/*const record = {fileCategory:"CV" , userID:"u20469366"}
+const record = {fileCategory:"CV" , userID:"u20469366"}
 class ApiStorageServiceMock {
   deleteFile(userID: string, fileCategory: string) {
     if(fileCategory.match(record.fileCategory)&&userID.match(record.userID)){
@@ -78,4 +78,4 @@ describe('StudentService', () => {
       expect(numexp).toEqual(num);
     });
   });
- });*/
+ });

--- a/libs/api/storage/api/feature/src/lib/api-storage.resolver.ts
+++ b/libs/api/storage/api/feature/src/lib/api-storage.resolver.ts
@@ -19,11 +19,14 @@ export class ApiStorageResolver {
   ): Promise<string | boolean> {
 
     let url :string|boolean = false;
-    await this.storageService.getFile(userID , fileCategory).then(async(value) => {
+    url = await this.storageService.getFile(userID , fileCategory);
+    /*await this.storageService.getFile(userID , fileCategory).then(async(value) => {
       if(value)
       url = value;
-    });
-    return url;
+    });*/
+    return new Promise<string | boolean>((resolve) => {
+      resolve(url);
+  });
 
   }
 
@@ -34,11 +37,15 @@ export class ApiStorageResolver {
   ): Promise<number> {
     
     let num = 0;
-    await this.storageService.deleteFile(userID , fileCategory).then(async(value) => {
-      num = value;
-    });
+    num = await this.storageService.deleteFile(userID , fileCategory);
 
-    return num;
+    /*await this.storageService.deleteFile(userID , fileCategory).then(async(value) => {
+      num = value;
+    });*/
+
+    return new Promise<number>((resolve) => {
+      resolve(num);
+  });
   }
 
   //TODO fix return type
@@ -76,12 +83,16 @@ export class ApiStorageResolver {
       storage.userId = userID;
       storage.fileExtension = fileExtension;
       
-      await this.storageService.create(storage).then( async (value) => {
+      if(await this.storageService.create(storage))
+      ret = true;
+      /*await this.storageService.create(storage).then( async (value) => {
         if(value)
         ret = true;
-      })
+      })*/
 
-      return ret;
+      return new Promise<boolean>((resolve) => {
+        resolve(ret);
+    });
 }
 @Query(() =>String)
   pingStorage(){

--- a/libs/api/storage/repository/data-access/src/lib/FirebaseRepository.repository.ts
+++ b/libs/api/storage/repository/data-access/src/lib/FirebaseRepository.repository.ts
@@ -49,7 +49,9 @@ export class FirebaseService {
       console.error(err);
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });
   }
 
   async uploadAsBase64String(base64: string, fileName: string, folderName: FirebaseFolders) : Promise<boolean>{
@@ -67,7 +69,9 @@ export class FirebaseService {
       console.error(err);
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });
   }
 
   async uploadAsBinaryString(binaryFile: string, fileName: string, folderName: FirebaseFolders) : Promise<boolean>{
@@ -88,7 +92,9 @@ export class FirebaseService {
       console.error(err);
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });;;
   }
 
   async getURLByName(fileName:string, folder:FirebaseFolders): Promise<string| null>{
@@ -102,7 +108,7 @@ export class FirebaseService {
     // This is analogous to a file path on disk
     console.log(fileRef.fullPath);
 
-    let url = null;
+    let url: string | null = null;
 
     //get the url that will download the file
     await getDownloadURL(fileRef)
@@ -113,7 +119,9 @@ export class FirebaseService {
         console.error(error);
       });
 
-    return url;
+    return new Promise<string | null>((resolve) => {
+      resolve(url);
+  });
   }
 
   async getURLByFilePath(file_path:string) : Promise<string|null>{
@@ -127,7 +135,7 @@ export class FirebaseService {
     // This is analogous to a file path on disk
     console.log(fileRef.fullPath);
 
-    let url = null;
+    let url: string | null = null;
 
     //get the url that will download the file
     await getDownloadURL(fileRef)
@@ -136,10 +144,11 @@ export class FirebaseService {
       })
       .catch((error) => {
         console.error(error);
-        return null;
       });
 
-    return url;
+    return new Promise<string | null>((resolve) => {
+      resolve(url);
+  });
   }
 
   async deleteByFilename(filename:string, folder:FirebaseFolders):Promise<boolean>{
@@ -157,7 +166,9 @@ export class FirebaseService {
       tempBool = false;
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });
   }
 
   //file_path = FirebaseFolder/filename
@@ -177,7 +188,9 @@ export class FirebaseService {
       tempBool = false;
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });
   }
   
   //ex. FirebaseRepository.uploadAllUnderDirectory('@graduates/api/storage/uploads',FirebaseRepository.FirebaseFolders.Files)
@@ -216,6 +229,8 @@ export class FirebaseService {
       });
     });
 
-    return tempBool;
+    return new Promise<boolean>((resolve) => {
+      resolve(tempBool);
+  });
   }
 }

--- a/libs/api/storage/repository/data-access/src/lib/StorageRepository.repository.ts
+++ b/libs/api/storage/repository/data-access/src/lib/StorageRepository.repository.ts
@@ -29,16 +29,18 @@ export class StorageRepository {
           });
         }     
       }
-    })
+    });
 
-    return ret;
+    return new Promise<string[]>((resolve) => {
+      resolve(ret);
+    });
 
   }
 
   //get a link to a specific user file
   async getUserFile(u_id: string, file_type:FileCategory): Promise<string|null> {
 
-    let ret = null;
+    let ret:string|null = null;
     await this.prismaService.userProfileFile.findFirst({
       where: {
           userId: u_id,
@@ -54,7 +56,10 @@ export class StorageRepository {
         }
       }
     );
-    return ret;
+
+    return new Promise<string|null>((resolve) => {
+      resolve(ret);
+    });
   }
 
   //create a file record if the user does not already added this file type
@@ -64,7 +69,7 @@ export class StorageRepository {
    const file_category = data.fileCategory;
    const file_name = u_id+file_category;
    
-   let file = null;
+   let file: UserProfileFile|null = null;
    await this.determineFirebaseFolder(file_category).then(async (folder) => {
       if(folder)
       {
@@ -95,7 +100,10 @@ export class StorageRepository {
       }
     }
    );
-   return file;
+
+   return new Promise<UserProfileFile|null>((resolve) => {
+    resolve(file);
+   });
   }
 
   async deleteFile(u_id: string, file_category:FileCategory){
@@ -123,8 +131,11 @@ export class StorageRepository {
     }).then(async (value) => {
       if(value)
       size = value.count;
-    })
-    return size;
+    });
+
+    return new Promise<number>((resolve) => {
+      resolve(size);
+    });
   }
 
   async deleteUserFiles(u_id: string){
@@ -153,8 +164,11 @@ export class StorageRepository {
     }).then(async (value) => {
       if(value)
       size = value.count;
-    })
-    return size;
+    });
+
+    return new Promise<number>((resolve) => {
+      resolve(size);
+    });
   }
 
   async updateUserFile(u_id:string,file_category:FileCategory,fileAsBase64:string){
@@ -171,13 +185,19 @@ export class StorageRepository {
 
    async determineFirebaseFolder(file_category:FileCategory): Promise<FirebaseFolders|null>{
     if(file_category==='CV' || file_category ==='DEGREE' || file_category ==='ACADEMIC_RECORD')
-    return FirebaseFolders.Files;
+    return new Promise<FirebaseFolders|null>((resolve) => {
+      resolve(FirebaseFolders.Files);
+    });
     if(file_category==='PROFILE_PHOTO')
-    return FirebaseFolders.ProfilePhotos;
+    return new Promise<FirebaseFolders|null>((resolve) => {
+      resolve(FirebaseFolders.ProfilePhotos);
+    });
     else
     {
     console.error('File Category not accepted');
-    return null;
+    return new Promise<FirebaseFolders|null>((resolve) => {
+      resolve(null);
+    });
     }
 
   }

--- a/libs/api/storage/service/feature/src/lib/api-storage-service-feature.ts
+++ b/libs/api/storage/service/feature/src/lib/api-storage-service-feature.ts
@@ -39,7 +39,11 @@ export class ApiStorageServiceFeatureModule {
           url = value;
         });
       }
-        return url;
+        return new Promise<string|null>((resolve) => {
+          resolve(url);
+      });;
+
+        
        
     }
 
@@ -72,7 +76,9 @@ export class ApiStorageServiceFeatureModule {
           num = value;
         });
       }
-        return num;
+        return new Promise<number>((resolve) => {
+          resolve(num);
+      });
     }
 
     async create(apiStorage: ApiStorage): Promise<ApiStorageInput|string>{
@@ -86,7 +92,9 @@ export class ApiStorageServiceFeatureModule {
         storage.filePath = value.filePath;
       });
 
-      return storage;
+      return new Promise<ApiStorageInput|string>((resolve) => {
+        resolve(storage);
+    });;
     }
    
   }


### PR DESCRIPTION
Fixing return types to all backend files because of confusion with returning promises and uncommenting resolver tests since they now run to completion.